### PR TITLE
Dark theme updates

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -58,7 +58,7 @@ const Menu: React.FC<Props> = ({ open, onClose }) => {
         .menu {
           display: none;
           flex-direction: column;
-          background: var(--color-red);
+          background: var(--color-menu);
           border-radius: 0.5rem;
           overflow: hidden;
         }
@@ -83,11 +83,11 @@ const Menu: React.FC<Props> = ({ open, onClose }) => {
         }
 
         .link:hover {
-          background: var(--color-red-light);
+          background: var(--color-menu-hover);
         }
 
         .link.active {
-          background: var(--color-red-dark);
+          background: var(--color-menu-active);
         }
       `}</style>
     </nav>

--- a/src/components/PreviewIndicator.tsx
+++ b/src/components/PreviewIndicator.tsx
@@ -16,7 +16,7 @@ const PreviewIndicator: React.FC = () => {
           left: 0;
           right: 0;
           z-index: 1;
-          background: var(--color-red);
+          background: var(--color-menu);
           text-align: center;
           color: white;
         }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,10 @@
 :root {
   --color-text: #333;
   --color-background: #fff;
-  --color-red: #c62127;
-  --color-red-light: #de3c41;
-  --color-red-dark: #9a1a1e;
+  --color-link: #c62127;
+  --color-menu: #c62127;
+  --color-menu-hover: #de3c41;
+  --color-menu-active: #9a1a1e;
   --color-border: #ddd;
   --color-shading: #f8f8f8;
   --font-serif: 'Alegreya', serif;
@@ -14,9 +15,10 @@
   :root {
     --color-text: #c0bab2;
     --color-background: #17191a;
-    --color-red: #9e1a1f;
-    --color-red-light: #e14b4f;
-    --color-red-dark: #7b1518;
+    --color-link: #f7586a;
+    --color-menu: #9e1a1f;
+    --color-menu-hover: #b73a3e;
+    --color-menu-active: #7b1518;
     --color-border: #2b2f31;
     --color-shading: #262a2b;
   }
@@ -52,13 +54,13 @@ h1 {
 }
 
 a {
-  color: var(--color-red);
+  color: var(--color-link);
   text-decoration: underline;
   text-decoration-color: var(--color-border);
 }
 
 a:hover {
-  text-decoration-color: var(--color-red);
+  text-decoration-color: var(--color-link);
 }
 
 ul,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "types": ["gtag.js"]
+    "types": ["gtag.js"],
+    "incremental": true
   },
   "exclude": ["node_modules"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
Brighten the color of links in dark theme to pass [accessibility checks](https://webaim.org/resources/contrastchecker/). Also slightly darken the menu hover color.

There were some files updates automatically when running `next dev` with the newest version of Next.js. Theese changes are included as well.