### PR TITLE
Specify time zone in date rendering

### DIFF
--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,4 +1,4 @@
 export function formatDate(isoDate: string) {
   const date = Date.parse(isoDate);
-  return new Intl.DateTimeFormat('sv-FI', { dateStyle: 'long' }).format(date);
+  return new Intl.DateTimeFormat('sv-FI', { dateStyle: 'long', timeZone: 'Europe/Helsinki' }).format(date);
 }


### PR DESCRIPTION
To avoid hydration errors.