### PR TITLE
Get contacts from contact page

### DIFF
--- a/src/contentful/data.ts
+++ b/src/contentful/data.ts
@@ -1,7 +1,7 @@
 import { getContentfulEntries, getContentfulEntry } from './client';
 import {
   TypeContact,
-  TypeContactSkeleton,
+  TypeContactPageSkeleton,
   TypePage,
   TypePageSkeleton,
   TypePost,
@@ -62,11 +62,10 @@ export async function fetchSidebar(slug: string | string[], preview?: boolean) {
   );
 }
 
-export async function fetchContacts(preview?: boolean) {
-  return getContentfulEntries<TypeContactSkeleton>(
+export async function fetchContactPage(preview?: boolean) {
+  return getContentfulEntry<TypeContactPageSkeleton>(
     {
-      content_type: 'contact',
-      order: ['fields.order', 'fields.name'],
+      content_type: 'contactPage',
     },
     preview,
   );

--- a/src/contentful/types/TypeContactPage.ts
+++ b/src/contentful/types/TypeContactPage.ts
@@ -1,0 +1,10 @@
+import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type { TypeContactSkeleton } from "./TypeContact";
+
+export interface TypeContactPageFields {
+    title: EntryFieldTypes.Symbol;
+    contacts?: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<TypeContactSkeleton>>;
+}
+
+export type TypeContactPageSkeleton = EntrySkeletonType<TypeContactPageFields, "contactPage">;
+export type TypeContactPage<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeContactPageSkeleton, Modifiers, Locales>;

--- a/src/contentful/types/index.ts
+++ b/src/contentful/types/index.ts
@@ -1,4 +1,5 @@
 export type { TypeContact, TypeContactFields, TypeContactSkeleton } from "./TypeContact";
+export type { TypeContactPage, TypeContactPageFields, TypeContactPageSkeleton } from "./TypeContactPage";
 export type { TypePage, TypePageFields, TypePageSkeleton } from "./TypePage";
 export type { TypePost, TypePostFields, TypePostSkeleton } from "./TypePost";
 export type { TypeSidebar, TypeSidebarFields, TypeSidebarSkeleton } from "./TypeSidebar";


### PR DESCRIPTION
Use the new `contactPage` content type to get a list of contacts to show on the `/kontakt` page. This makes it easier to show, hide and reorder contacts. Once this change is merged, we can remove the order field from `contact`.