### PR TITLE
fix: button color in dark mode

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -105,6 +105,8 @@ input {
 button {
   padding: 8px 12px;
   background: var(--color-border);
+  color: var(--color-text);
+  cursor: pointer;
   border: 1px solid var(--color-text);
   border-radius: 4px;
 }


### PR DESCRIPTION
This button looked wrong in dark mode. Also added cursor: pointer to indicate that it is clickable.

![image](https://github.com/user-attachments/assets/8547d4af-552b-44f2-9b4d-65f7c944000b)
